### PR TITLE
Crystal geometry corrections

### DIFF
--- a/macros/geantino_confine.mac
+++ b/macros/geantino_confine.mac
@@ -1,0 +1,67 @@
+#STORE PRIMARIES
+/writePrimaries true
+
+#VERBOSITY
+/control/verbose  0
+/run/verbose      0     
+/event/verbose    0
+/tracking/verbose 0
+
+# particle type + energy spectrum
+/GeMSE/gun/particle geantino
+
+#CONFINEMENT
+/GeMSE/gun/type Volume
+/GeMSE/gun/shape Cylinder
+/GeMSE/gun/radius 7. cm
+/GeMSE/gun/halfz 7.5 cm
+/GeMSE/gun/center 0 0 0 cm
+/GeMSE/gun/angtype iso
+
+#RUN
+#/GeMSE/gun/confine Ge_detector
+#/analysis/setFileName geantino_Ge.root
+#/run/beamOn 200000
+
+#/GeMSE/gun/confine Li_contact
+#/analysis/setFileName geantino_LiContact.root
+#/run/beamOn 200000
+
+#/GeMSE/gun/halfz 10. cm
+#/GeMSE/gun/center 0 0 -6 cm
+#/GeMSE/gun/confine TeflonHolder
+#/analysis/setFileName geantino_TeflonHolder.root
+#/run/beamOn 200000
+
+#/GeMSE/gun/confine DetHolder
+#/analysis/setFileName geantino_DetHolder.root
+#/run/beamOn 200000
+
+#/GeMSE/gun/radius 8. cm
+#/GeMSE/gun/halfz 20. cm
+#/GeMSE/gun/center 0 0 0 cm
+#/GeMSE/gun/confine CuHsg
+#/analysis/setFileName geantino_CuCryo.root
+#/run/beamOn 200000
+
+#/GeMSE/gun/radius 80. cm
+#/GeMSE/gun/halfz 70. cm
+#/GeMSE/gun/center 0 0 0 cm
+#/GeMSE/gun/confine CuShielding CuPlateFixed CuPlateMovable
+#/analysis/setFileName geantino_Cushield.root
+#/run/beamOn 200000
+
+#/GeMSE/gun/confine innerPbShielding innerPbShieldingFixed innerPbShieldingMovable
+#/analysis/setFileName geantino_InnerPbShield.root
+#/run/beamOn 200000
+
+#/GeMSE/gun/confine outerPbShielding outerPbShieldingFixed outerPbShieldingMovable
+#/analysis/setFileName geantino_OuterPbShield.root
+#/run/beamOn 200000
+
+/GeMSE/gun/radius 100. cm
+/GeMSE/gun/halfz 2. cm
+/GeMSE/gun/center 0 0 -15 cm
+/GeMSE/gun/confine Coldfinger
+/analysis/setFileName geantino_Coldfinger.root
+/run/beamOn 200000

--- a/sample_geometries/CBSS2_source.cc
+++ b/sample_geometries/CBSS2_source.cc
@@ -51,6 +51,8 @@ new G4PVPlacement(0, G4ThreeVector(0., 0., zPosCBSS2),
                   CBSS2_log, "CBSS2", expHall_log, false, 0);
 
 // Visualization attributes
+G4VisAttributes* violet = new G4VisAttributes(G4Colour(0.5,0.0,1.0));
+G4VisAttributes* lightblue = new G4VisAttributes(G4Colour(0.0,0.5,1.0));
 PS_log->SetVisAttributes(lightblue);
 CBSS2_log->SetVisAttributes(violet);
 

--- a/sample_geometries/ptb_sources.cc
+++ b/sample_geometries/ptb_sources.cc
@@ -1,0 +1,67 @@
+////////////////////////////////////////////////////////////
+// To be called from the GeMSE_DetectorConstruction class //
+////////////////////////////////////////////////////////////
+
+// Assembly for the calibration sources setup
+// Sample 2021-05-26
+
+// Point-like cylindrical calibration sources on top of a holder system
+// provided by Rugard Dresler (PSI)
+// Standard dimensions of point sources by PTB:
+// https://www.ptb.de/cms/en/ptb/fachabteilungen/abt6/fb-61/611-unit-of-activity/
+//   delivery-of-activity-standards/activity-standards-in-the-form-of-solid-sources.html
+
+// Holders from CAD STL files
+// Source as simply tube embeded in polyethylene
+
+// Dimensions
+G4double dSourceThickness = 1.*mm;
+G4double dSourceDiameter = 5*mm;
+G4double dContainerThickness = 1.*mm;
+G4double dContainerDiameter = 24*mm;
+G4double zPosSource = 113.8*mm
+   + zPosEndcap + heightEndcap/2.;
+
+// Materials
+G4Material* aluminium_mat = nist->FindOrBuildMaterial("G4_Al");
+G4Material* ps_mat = nist->FindOrBuildMaterial("G4_POLYETHYLENE");
+
+// Sample position and rotation
+G4RotationMatrix rmr;
+rmr.rotateX(180.*deg);
+rmr.rotateZ(0.*deg);
+G4ThreeVector sample_pos = G4ThreeVector(0, 0, zPosSource + 1.*mm);
+// Just because of the coordinates in the STL file
+
+G4LogicalVolume *holder_logical;
+
+// Import holder
+auto holder_mesh = CADMesh::TessellatedMesh::FromSTL
+   ("sample_geometries/Holders_assembly_reduced.stl");
+holder_mesh->SetScale(10.0); // Default is 1, corresponding to mm in Geant4
+auto holder_solid = holder_mesh->GetSolid();
+holder_logical = new G4LogicalVolume(holder_solid, aluminium_mat,
+                                     "source_holder_logical", 0, 0, 0);
+//new G4PVPlacement(G4Transform3D(rmr, sample_pos), holder_logical,
+//                  "source_holder", expHall_log, false, 0);
+
+// Calibration source
+G4Tubs* container_tube = new G4Tubs ("container_tube", 0., dContainerDiameter/2.,
+                                   dContainerThickness/2., 0., 360.*deg);
+G4Tubs* ps_tube = new G4Tubs ("ps_tube", 0., dSourceDiameter/2.,
+                              dSourceThickness/2., 0., 360.*deg);
+
+G4LogicalVolume* container_log = new G4LogicalVolume(container_tube, ps_mat, "container_log", 0, 0, 0);
+new G4PVPlacement(0, G4ThreeVector(0., 0., zPosSource+dContainerThickness/2.),
+                  container_log, "source_container", expHall_log, false, 0);
+
+G4LogicalVolume* ps_log = new G4LogicalVolume(ps_tube, ps_mat, "ps_log", 0, 0, 0);
+new G4PVPlacement(0, G4ThreeVector(0., 0., 0),
+                  ps_log, "calibration_source", container_log, false, 0);
+
+// Visualization G4VisAttributes
+G4VisAttributes* violet = new G4VisAttributes(G4Colour(0.5,0.0,1.0));
+G4VisAttributes* lightblue = new G4VisAttributes(G4Colour(0.0,0.5,1.0));
+holder_logical->SetVisAttributes(grey);
+container_log->SetVisAttributes(lightblue);
+ps_log->SetVisAttributes(violet);

--- a/src/GeMSE_DetectorConstruction.cc
+++ b/src/GeMSE_DetectorConstruction.cc
@@ -880,10 +880,11 @@ G4VPhysicalVolume* GeMSE_DetectorConstruction::Construct() {
   // substract hole from cylinder
   G4Tubs* Hole_tube =
       new G4Tubs("Hole_tube", 0. * cm, outerRadiusHole,
-                 heightHole / 2. + 0.005 * cm, startAngle, spanningAngle);
+                 heightHole / 2., startAngle, spanningAngle);
   G4SubtractionSolid* GeIn_sub = new G4SubtractionSolid(
       "GeIn_sub", GeIn_tube, Hole_tube, 0,
-      G4ThreeVector(0., 0., -(heightGe / 2. - heightHole / 2. + 0.005 * cm)));
+      G4ThreeVector(0., 0., (- heightGe + d_LiContact + heightHole) / 2.));
+  
 
   /*
   G4Tubs*			GeCenterIn_tube     = new G4Tubs
@@ -917,13 +918,11 @@ G4VPhysicalVolume* GeMSE_DetectorConstruction::Construct() {
                  startAngle, spanningAngle);
   G4Tubs* LiOuterContact_tube = new G4Tubs(
       "LiOuterContact_tube", outerRadiusGe - d_LiContact, outerRadiusGe,
-      (heightGe - d_LiContact) / 2. + 0.0001 * cm, startAngle, spanningAngle);
+      (heightGe - d_LiContact) / 2., startAngle, spanningAngle);
 
   G4UnionSolid* LiContact_uni = new G4UnionSolid(
       "LiContact_uni", LiWindow_tube, LiOuterContact_tube, 0,
-      G4ThreeVector(
-          0., 0.,
-          -d_LiContact / 2. - (heightGe - d_LiContact) / 2. + 0.0001 * cm));
+      G4ThreeVector(0., 0., - heightGe / 2.));
 
   /*
   G4Tubs*			GeCenter_tube 	= new G4Tubs ("GeCenter_tube",
@@ -967,7 +966,6 @@ G4VPhysicalVolume* GeMSE_DetectorConstruction::Construct() {
 
   G4LogicalVolume* Ge_log =
       new G4LogicalVolume(GeIn_sub, germanium_mat, "Ge_log", 0, 0, 0);
-
   G4LogicalVolume* LiContact_log = new G4LogicalVolume(
       LiContact_uni, germanium_mat, "LiContact_log", 0, 0, 0);
 

--- a/src/GeMSE_DetectorConstruction.cc
+++ b/src/GeMSE_DetectorConstruction.cc
@@ -845,10 +845,10 @@ G4VPhysicalVolume* GeMSE_DetectorConstruction::Construct() {
   // Teflon holder
   G4Tubs* TeflonHolder_top_tube =
       new G4Tubs("TeflonHolder_top_tube", 0. * cm,
-                 outerRadiusGe + d_TefHolder_side + 0.001 * cm,
-                 d_TefHolder_top / 2. + 0.001 * cm, startAngle, spanningAngle);
+                 outerRadiusGe + d_TefHolder_side,
+                 d_TefHolder_top / 2., startAngle, spanningAngle);
   G4Tubs* TeflonHolder_side_tube = new G4Tubs(
-      "TeflonHolder_side_tube", outerRadiusGe + 0.005 * cm,
+      "TeflonHolder_side_tube", outerRadiusGe,
       outerRadiusGe + d_TefHolder_side,
       (heightTeflonHolder - d_TefHolder_top) / 2., startAngle, spanningAngle);
 


### PR DESCRIPTION
Minor:
- Updated CBSS2 volume construction with needed vis attributes.
- Added calibration source volume for the May 2021 run
- Added geantino_confine macro for volume plotting

Major:
- Modify placement of the Ge crystal with respect to the dead layer volume. This was not correctly done in the past, since setting a thicker dead layer was simply pushing the Ge crystal downwards, rather than making it remain at the same place, but reducing its size (as it should be the case). Now that's this is corrected, the user only needs to care about corrected, so that the user will only need to care about modifying these lines, and the placement will be automatically done:
```
  // outer contact
  G4double d_LiContact = 0.067 * cm;
```
Example `geantino_tracking` output for a 0.067 cm dead layer:

```
*********************************************************************************************************
* G4Track Information:   Particle = geantino,   Track ID = 1,   Parent ID = 0
*********************************************************************************************************

Step#    X(mm)    Y(mm)    Z(mm) KinE(MeV)  dE(MeV) StepLeng TrackLeng  NextVolume ProcName
    0        0        0     32.5         1        0        0         0 TeflonHolder initStep
    1        0        0     32.5         1        0     0.01      0.01   VacuumDet Transportation
    2        0        0     32.5         1        0     0.04      0.05  Li_contact Transportation
    3        0        0     31.8         1        0     0.67      0.72 Ge_detector Transportation
    4        0        0       10         1        0     21.8      22.6   VacuumDet Transportation
    5        0        0     -179         1        0      189       212       CuHsg Transportation
    6        0        0     -182         1        0        3       215 CuShielding Transportation
    7        0        0     -256         1        0     73.4       288       World Transportation
    8        0        0     -256         1        0     0.01       288 innerPbShielding Transportation
    9        0        0     -306         1        0       50       338       World Transportation
   10        0        0     -306         1        0     0.01       338 outerPbShielding Transportation
   11        0        0     -456         1        0      150       488       World Transportation
   12        0        0   -1e+04         1        0 9.54e+03     1e+04  OutOfWorld Transportation
```

... and for a 0.267 cm dead layer

```
*********************************************************************************************************
* G4Track Information:   Particle = geantino,   Track ID = 1,   Parent ID = 0
*********************************************************************************************************

Step#    X(mm)    Y(mm)    Z(mm) KinE(MeV)  dE(MeV) StepLeng TrackLeng  NextVolume ProcName
    0        0        0     32.5         1        0        0         0 TeflonHolder initStep
    1        0        0     32.5         1        0     0.01      0.01   VacuumDet Transportation
    2        0        0     32.5         1        0     0.04      0.05  Li_contact Transportation
    3        0        0     29.8         1        0     2.67      2.72 Ge_detector Transportation
    4        0        0       10         1        0     19.8      22.5   VacuumDet Transportation
    5        0        0     -179         1        0      189       212       CuHsg Transportation
    6        0        0     -182         1        0        3       215 CuShielding Transportation
    7        0        0     -256         1        0     73.4       288       World Transportation
    8        0        0     -256         1        0     0.01       288 innerPbShielding Transportation
    9        0        0     -306         1        0       50       338       World Transportation
   10        0        0     -306         1        0     0.01       338 outerPbShielding Transportation
   11        0        0     -456         1        0      150       488       World Transportation
   12        0        0   -1e+04         1        0 9.54e+03     1e+04  OutOfWorld Transportation
```

One can see that the distance `VacuumDet`-`CuHsg` remains, and the `Ge_detector` thickness varies (the opposite happened before applying this correction).